### PR TITLE
Fix status comparison and centralize status constants

### DIFF
--- a/backend/constants/statuses.js
+++ b/backend/constants/statuses.js
@@ -1,0 +1,4 @@
+// Central list of valid Application status values
+const APPLICATION_STATUSES = ['Pending', 'Complete', 'Rejected'];
+
+module.exports = { APPLICATION_STATUSES };

--- a/backend/controllers/applicationController.js
+++ b/backend/controllers/applicationController.js
@@ -1,5 +1,7 @@
 const Application = require('../models/Application');
 const Meeting = require('../models/Meeting');
+// Allowed status values shared across the backend
+const { APPLICATION_STATUSES } = require('../constants/statuses');
 
 exports.createApplication = async (req, res) => {
   try {
@@ -59,7 +61,8 @@ exports.updateApplication = async (req, res) => {
 
     // Check permissions
     const isOwner = application.userId.toString() === req.user._id.toString();
-    const isPending = application.status === 'pending';
+    const PENDING_STATUS = APPLICATION_STATUSES[0];
+    const isPending = application.status === PENDING_STATUS;
 
     console.log('Permission check:', {
       isOwner,

--- a/backend/models/Application.js
+++ b/backend/models/Application.js
@@ -1,4 +1,6 @@
 const mongoose = require('mongoose');
+// Re-use status values across the codebase
+const { APPLICATION_STATUSES } = require('../constants/statuses');
 
 const applicationSchema = new mongoose.Schema({
   userId: {
@@ -129,8 +131,8 @@ const applicationSchema = new mongoose.Schema({
   // Administrative Fields
   status: {
     type: String,
-    enum: ['Pending','Complete','Rejected'],
-    default: 'Pending'
+    enum: APPLICATION_STATUSES,
+    default: APPLICATION_STATUSES[0]
   },
   letterEmailedDate: {
     type: Date

--- a/backend/routes/applications.js
+++ b/backend/routes/applications.js
@@ -5,6 +5,7 @@ const multer = require('multer');
 const { parse } = require('csv-parse');
 const Meeting = require('../models/Meeting');
 const Application = require('../models/Application');
+const { APPLICATION_STATUSES } = require('../constants/statuses');
 const upload = multer({ storage: multer.memoryStorage() });
 
 // Add this helper function at the top
@@ -168,7 +169,7 @@ router.post('/import', auth, upload.single('file'), async (req, res) => {
         const application = new Application({
           // System fields
           userId: req.user._id,
-          status: record.status?.toLowerCase() === 'complete' ? 'Complete' : 'Pending',
+          status: record.status?.toLowerCase() === 'complete' ? 'Complete' : APPLICATION_STATUSES[0],
           entryDate: applicationDate,
           createdAt: applicationDate,  // This should now stick due to immutable: true
           
@@ -336,7 +337,7 @@ router.post('/', auth, async (req, res) => {
     const application = new Application({
       ...req.body,
       userId: req.user._id,
-      status: 'Pending'
+      status: APPLICATION_STATUSES[0]
     });
     
     await application.save();

--- a/backend/utils/importExcel.js
+++ b/backend/utils/importExcel.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const Application = require('../models/Application');
 const User = require('../models/User');
 const { sendEmail } = require('./sendEmail');
+const { APPLICATION_STATUSES } = require('../constants/statuses');
 
 exports.importApplications = async (filePath, adminUserId) => {
   return new Promise((resolve, reject) => {
@@ -43,7 +44,7 @@ exports.importApplications = async (filePath, adminUserId) => {
             phoneNumber: data.phoneNumber,
             organization: data.organization,
             role: data.role,
-            status: data.status || 'pending',
+            status: data.status || APPLICATION_STATUSES[0],
             submittedAt: new Date(data.submittedDate) || new Date(),
             lastUpdatedBy: adminUserId
           });

--- a/frontend/src/components/admin/CSVTemplateDownload.tsx
+++ b/frontend/src/components/admin/CSVTemplateDownload.tsx
@@ -59,7 +59,7 @@ export default function CSVTemplateDownload() {
     'ABC123',
     'No special requirements',
     'Calgary 2026',  // Use the actual meeting name
-    'pending',
+    'Pending',
     '',
     '',
     '',


### PR DESCRIPTION
## Summary
- centralize allowed statuses in `backend/constants/statuses.js`
- reference the new constant in model, controller, import utility and routes
- fix status comparison to use `Pending`
- update CSV template example to use proper casing

------
https://chatgpt.com/codex/tasks/task_e_6846f08485648328b41ab8f7475e8cb4